### PR TITLE
Fix bug in prediction input field

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,5 +40,5 @@ EXAMPLES = {
 @app.post("/predict")
 def predict(request: PredictRequest = Body(..., openapi_examples=EXAMPLES)):
     assert model is not None
-    results = model(request.input, **request.parameters)
+    results = model(request.inputs, **request.parameters)
     return results


### PR DESCRIPTION
This pull request addresses the bug where the `predict` function was referencing `request.input` instead of `request.inputs`. This change fixes the error by correcting the attribute name to align with the `PredictRequest` model definition.